### PR TITLE
Arrumando CamelCase no require do FileUtils

### DIFF
--- a/lib/active_file.rb
+++ b/lib/active_file.rb
@@ -1,7 +1,7 @@
 # coding utf-8
 
 require "yaml"
-require "FileUtils"
+require "fileutils"
 require "active_file/version"
 
 require "rake"


### PR DESCRIPTION
Estava dando um problema no linux ao carregar o FileUtils com CamelCase.
O require com CamelCase encontra-se no seu livro também.

```
LoadError: cannot load such file -- FileUtils
    from /home/roberto/.rvm/rubies/ruby-2.2.1/lib/ruby/site_ruby/2.2.0/rubygems/core_ext/kernel_require.rb:54:in `require'
    from /home/roberto/.rvm/rubies/ruby-2.2.1/lib/ruby/site_ruby/2.2.0/rubygems/core_ext/kernel_require.rb:54:in `require'
    from /home/roberto/.rvm/gems/ruby-2.2.1/gems/active_file-0.0.2.3/lib/active_file.rb:3:in `<top (required)>'
    from /home/roberto/.rvm/rubies/ruby-2.2.1/lib/ruby/site_ruby/2.2.0/rubygems/core_ext/kernel_require.rb:128:in `require'
    from /home/roberto/.rvm/rubies/ruby-2.2.1/lib/ruby/site_ruby/2.2.0/rubygems/core_ext/kernel_require.rb:128:in `rescue in require'
    from /home/roberto/.rvm/rubies/ruby-2.2.1/lib/ruby/site_ruby/2.2.0/rubygems/core_ext/kernel_require.rb:39:in `require'
    from /home/roberto/Documentos/ruby/loja_virtual/load.rb:2:in `<top (required)>'
    from (irb):1:in `require_relative'
    from (irb):1
    from /home/roberto/.rvm/rubies/ruby-2.2.1/bin/irb:11:in `<main>'

```
